### PR TITLE
Update smartRenew.sh

### DIFF
--- a/smartRenew.sh
+++ b/smartRenew.sh
@@ -5,7 +5,7 @@ NOW=$(date +%s)
 # Get the expiry date of our certificate.
 EXPIRE=$(openssl x509 -in /path/to/signed.crt -noout -enddate)
 # Trim the unecessary text at the start of the string.
-EXPIRE=${EXPIRE:9}
+EXPIRE=${EXPIRE#*=}
 # Convert the expiry date to seconds since epoch.
 EXPIRE=$(date --date="$EXPIRE" +%s)
 # Calculate the time left until the certificate expires.


### PR DESCRIPTION
Rather than relying on the prefix being 9 characters long, explicitly state is should remove everything before the "="
