### PR TITLE
Backup old cert on renew

### DIFF
--- a/smartRenew.sh
+++ b/smartRenew.sh
@@ -3,7 +3,7 @@
 # The remaining life on our certificate below which we should renew (7 days).
 RENEW=7
 # Set date for backup
-TODAY=`date '+%Y_%m_%d'`;
+TODAY=`date '+%Y_%m_%d'`
 # If the certificate has less life remaining than we want.
 if ! openssl x509 -checkend $[ 86400 * $RENEW ] -noout -in /path/to/signed.crt
         then

--- a/smartRenew.sh
+++ b/smartRenew.sh
@@ -2,9 +2,13 @@
 
 # The remaining life on our certificate below which we should renew (7 days).
 RENEW=7
+# Set date for backup
+TODAY=`date '+%Y_%m_%d'`;
 # If the certificate has less life remaining than we want.
 if ! openssl x509 -checkend $[ 86400 * $RENEW ] -noout -in /path/to/signed.crt
         then
+                # Then make backup copy of existing cert before starting renew
+                cp /path/to/signed.crt /path/to/old/signed_backup_$TODAY.crt
                 # Then call the renewal script.
                 ./path/to/renew.sh
 fi


### PR DESCRIPTION
If everything works OK this might not be necessary, but for my own setup based in your smartRenew-script I felt like keeping a backup of the cert being replaced before the file signed.crt is overwritten.

So i made some lines of code that backs up the cert file in /old/signed_backup_date.crt
(on the form signed_backup_2017_01_21.crt using the date of the renew operation)